### PR TITLE
Add option for target name to be used as the MQTT topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
-    name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
+    target_name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
+    name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/src/config_schema.ts
+++ b/src/config_schema.ts
@@ -148,6 +148,10 @@ export const schema = {
                     type: "boolean",
                     default: true,
                 },
+                target_name_as_topic: {
+                    type: "boolean",
+                    default: false,
+                },
             },
             additionalProperties: false,
         },

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -110,9 +110,9 @@ export const createClient = async (
     return {
         publish,
         sensorStatusTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/status`,
+            `snmp2mqtt/${config.target_name_as_topic && target.name ? slugify(target.name) : target.host}/${slugify(sensor.name)}/status`,
         sensorValueTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/value`,
+            `snmp2mqtt/${config.target_name_as_topic && target.name ? slugify(target.name) : target.host}/${slugify(sensor.name)}/value`,
         STATUS_TOPIC,
         ONLINE,
         OFFLINE,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface MQTTConfig {
     key?: string;
     clean: boolean;
     reject_unauthorized?: boolean;
+    target_name_as_topic?: boolean;
 }
 
 export interface TargetConfig {


### PR DESCRIPTION
## Intent

Adds an optional parameter to the MQTT configuration to use the target's name as the second topic level rather than the hostname.

## Example

```yaml
# config.yml

mqtt:
  # < snip >
  target_name_as_topic: true

targets:
  - host: 192.168.8.81
    name: UPS 3301
    version: 1
    sensors:
      - oid: 1.3.6.1.4.1.3808.1.1.1.1.1.1.0
        name: Model Number
```

### Effect

* before setting `target_name_as_topic`: messages are published to `.../192.168.8.81/...`
* after setting `target_name_as_topic`: messages are published to `.../ups_3301/...` 

<img width="301" alt="image" src="https://user-images.githubusercontent.com/1703560/203854185-7e4fdc73-161e-438d-b983-5381b8ecab38.png">
