### PR TITLE
Add parameter to configure MQTT base topic level

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
+    base_topic: # Optional: the base level of the topic (default snmp2mqtt)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
-    base_topic: # Optional: the base level of the topic (default snmp2mqtt)
+    base_topic: # Optional: the base level of the topic (default: snmp2mqtt)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/src/config_schema.ts
+++ b/src/config_schema.ts
@@ -148,6 +148,10 @@ export const schema = {
                     type: "boolean",
                     default: true,
                 },
+                base_topic: {
+                    type: "string",
+                    default: "snmp2mqtt",
+                },
             },
             additionalProperties: false,
         },

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -110,9 +110,9 @@ export const createClient = async (
     return {
         publish,
         sensorStatusTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/status`,
+            `${config.base_topic}/${target.host}/${slugify(sensor.name)}/status`,
         sensorValueTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/value`,
+            `${config.base_topic}/${target.host}/${slugify(sensor.name)}/value`,
         STATUS_TOPIC,
         ONLINE,
         OFFLINE,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface MQTTConfig {
     key?: string;
     clean: boolean;
     reject_unauthorized?: boolean;
+    base_topic?: string;
 }
 
 export interface TargetConfig {


### PR DESCRIPTION
## Intent

Adds a configuration parameter to set the MQTT base topic level

## Example

```yaml
mqtt:
  # < snip >
  base_topic: snmp
```

### Effect

* before setting `base_topic`: messages are published to `snmp2mqtt/...`
* after setting `base_topic`: messages are published to `snmp/...` 

<img width="291" alt="image" src="https://user-images.githubusercontent.com/1703560/204103265-4453fd10-0f7d-49b7-9398-1f8db3ffed41.png">
